### PR TITLE
missing header

### DIFF
--- a/dijkstra.c
+++ b/dijkstra.c
@@ -1,4 +1,5 @@
 #include "dijkstra.h"
+#include <limits.h>
 #include <stdio.h>
 #include "airport.h"
 #include "flight.h"


### PR DESCRIPTION
dijkstra.c:2:1: note: ‘INT_MAX’ is defined in header ‘<limits.h>’; did you forget to ‘#include <limits.h>’?
    1 | #include "dijkstra.h"
  +++ |+#include <limits.h>
    2 | #include <stdio.h>